### PR TITLE
Remove track equivalent and unused method

### DIFF
--- a/lib/mormon/osm_loader.rb
+++ b/lib/mormon/osm_loader.rb
@@ -207,15 +207,6 @@ module Mormon
           @routing[route_type][fr] = { to => weight }
         end
 
-        def way_type(tags)
-          # Look for a variety of tags (priority order - first one found is used)
-          [:highway, :railway, :waterway, :natural].each do |type|
-            value = tags.fetch(type, '')
-            return equivalent(value) if value
-          end
-          nil
-        end
-
         def equivalent(tag)
           { 
             primary_link:   "primary",
@@ -230,7 +221,6 @@ module Mormon
             driveway:       "service",
             pedestrian:     "footway",
             bridleway:      "cycleway",
-            track:          "cycleway",
             arcade:         "footway",
             canal:          "river",
             riverbank:      "river",


### PR DESCRIPTION
When passed `:track`, `equivalent` will return `cycleway`. This messes up `foot` routing as it will return 0.2 weight instead of 1 (compare https://github.com/geronimod/mormon/blob/master/lib/mormon/weight.rb#L14 vs https://github.com/geronimod/mormon/blob/master/lib/mormon/weight.rb#L12). Since we have weights for `track` I think it's better to just remove that mapping.

Also remove `way_type`, doesn't seem to be used anywhere.